### PR TITLE
[null issue] adds default locale to this.state.locale

### DIFF
--- a/src/preview/containers/WithIntl/index.js
+++ b/src/preview/containers/WithIntl/index.js
@@ -10,7 +10,7 @@ class WithIntl extends React.Component {
         super(props);
 
         this.state = {
-            locale: null
+            locale: props.intlConfig.defaultLocale
         };
 
         this.setLocale = this.setLocale.bind(this);


### PR DESCRIPTION
hi @floriangosse I tried to render the stories however all I got was blank page.

It's related to the initial state of locale `this.state = { locale: null }` I set it up to defaultLocale.

If `channel.emit(EVENT_GET_LOCALE_ID)` doesn't _trigger_ `setLocale` then blank page is render.

Let me know your thoughts on this, thanks