### PR TITLE
Remove reliance on IntlProvider proptypes

### DIFF
--- a/src/preview/containers/WithIntl/index.js
+++ b/src/preview/containers/WithIntl/index.js
@@ -59,7 +59,15 @@ class WithIntl extends React.Component {
 }
 
 WithIntl.propTypes = {
-    intlConfig: PropTypes.shape(omit(IntlProvider.propTypes, ['children'])).isRequired,
+    intlConfig: PropTypes.shape(
+      locale: PropTypes.string,
+      formats: PropTypes.object,
+      messages: PropTypes.object,
+      textComponent: PropTypes.any,
+      defaultLocale : PropTypes.string,
+      initialNow: PropTypes.any,
+      defaultFormats: PropTypes.object
+    ).isRequired,
     locales: PropTypes.arrayOf(PropTypes.string).isRequired,
     getMessages: PropTypes.func.isRequired,
     channel: PropTypes.shape({


### PR DESCRIPTION
Relying on the `propTypes` of another package for this library's own `propTypes` will cause issues down the road: https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types#is-it-safe

Specifically for my project, it's causing issues when we run our code through `babel-plugin-transform-react-remove-prop-types`, which removes the `propTypes` from `IntlProvider`, but this add-on still depends on it.

This PR is to just remove reliance on `IntlProvider`'s propTypes