### PR TITLE
Force component tree re-rendering

### DIFF
--- a/src/preview/containers/WithIntl/index.js
+++ b/src/preview/containers/WithIntl/index.js
@@ -51,7 +51,7 @@ class WithIntl extends React.Component {
         const messages = getMessages(locale);
 
         return (
-            <IntlProvider {...intlConfig} locale={locale} messages={messages}>
+            <IntlProvider {...intlConfig} key={locale} locale={locale} messages={messages}>
                 {children}
             </IntlProvider>
         );


### PR DESCRIPTION
When using redux, due to shouldComponentUpdate optimisations, the locales are not automatically reflected when a new language is selected on the Locale panel. This MR adds the locale as a key to the IntlProvider to address this issue.

See: https://github.com/yahoo/react-intl/issues/234