### PR TITLE
Allow react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@storybook/react": "^3.1.0",
-    "react": "^15.4.0",
+    "react": "^15.4.0 || ^16.0.0",
     "react-intl": "^2.3.0"
   },
   "engines": {


### PR DESCRIPTION
Didn't change the devDependency for `react-dom` and test utils, just allow react 16 in dependency to avoid peerDependency warning 