### PR TITLE
Move @storybook/addons to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First, install the addon
 npm install -D storybook-addon-intl
 ```
 
-_Note: Following peer dependencies are required: `@storybook/react`, `react` and `react-intl`._
+_Note: Following peer dependencies are required: `@storybook/addons`, `@storybook/react`, `react` and `react-intl`._
 
 Add this line to your `addons.js` file (create this file inside your storybook config directory if needed).
 
@@ -57,3 +57,14 @@ addDecorator(withIntl);
 // Run storybook
 configure(() => require('./stories'), module);
 ```
+
+## Troubleshooting
+
+##### _Accessing nonexistent addons channel_ error:
+This error can be caused by multiple conflicting versions of `@storybook/addons` in your app.
+
+-   Ensure that the entries starting with `@storybook/addon-` in your `package.json` refer to the same and latest version.
+-   Add the latest version of `@storybook/addons` to your app's `dependencies` and reinstall all modules.
+
+If the above steps don't solve the issue, please read the [storybook documentation](https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel) on this topic:
+> Most of the time, the fix is deleting the node_modules folder with any package-lock.json or yarn.lock and reinstalling.

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/truffls/storybook-addon-intl#readme",
   "dependencies": {
-    "@storybook/addons": "^3.1.0",
     "prop-types": "^15.5.0"
   },
   "devDependencies": {
-    "@storybook/react": "^3.1.0",
+    "@storybook/addons": "^3.2.16",
+    "@storybook/react": "^3.2.16",
     "babel-cli": "^6.14.0",
     "babel-jest": "^20.0.3",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
@@ -47,7 +47,8 @@
     "shelljs": "^0.7.4"
   },
   "peerDependencies": {
-    "@storybook/react": "^3.1.0",
+    "@storybook/addons": "^3.2.16",
+    "@storybook/react": "^3.2.16",
     "react": "^15.4.0 || ^16.0.0",
     "react-intl": "^2.3.0"
   },


### PR DESCRIPTION
Moves `@storybook/addons `to `peerDependencies` and alerts the user in the `README`, should help with `Accessing nonexistent addons channel` errors if the user also installs it as a dependency in the main app.

This modification has been applied to all official storybook addons: storybooks/storybook#2335 and released in versions: 3.3.0-alpha*

Also see  #13.