### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "BABEL_ENV=production node scripts/build.js",
+    "deploy-storybook": "storybook-to-ghpages",
     "prepublish": "npm run build",
     "prestorybook": "npm run build",
     "storybook": "start-storybook -p 9001",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@storybook/addons": "^3.2.16",
     "@storybook/react": "^3.2.16",
+    "@storybook/storybook-deployer": "^2.3.0",
     "babel-cli": "^6.14.0",
     "babel-jest": "^20.0.3",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",


### PR DESCRIPTION
Make it possible to publish storybook to github pages using `npm run storybook-deployer`.

This will make it possible to easily publish the demo storybook for the project to github pages, so that people can easily see the addon in action, at http://truffls.github.io/storybook-addon-intl, which can easily be linked in the README.