### PR TITLE
Update storybook peer dependencies to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "shelljs": "^0.7.4"
   },
   "peerDependencies": {
-    "@storybook/addons": "^3.2.16",
-    "@storybook/react": "^3.2.16",
+    "@storybook/addons": "^3.2.16 || ^4.0.6",
+    "@storybook/react": "^3.2.16 || ^4.0.6",
     "react": "^15.4.0 || ^16.0.0",
     "react-intl": "^2.3.0"
   },


### PR DESCRIPTION
This addon is working with Storybook 4 and was updated for it. Adding it as a peer dependency so NPM doesn't complain.

Currently using Storybook v4 with 2.3.1 and it's working great! Just want to get rid of the NPM warnings.