### PR TITLE
Define peerDependencies differently to fix npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "shelljs": "^0.7.4"
   },
   "peerDependencies": {
-    "@storybook/addons": "^3.2.16 || ^4.0.6",
-    "@storybook/react": "^3.2.16 || ^4.0.6",
-    "react": "^15.4.0 || ^16.0.0",
-    "react-intl": "^2.3.0"
+    "@storybook/addons": ">= 3.2.16",
+    "@storybook/react": ">= 3.2.16",
+    "react": ">= 15.4.0",
+    "react-intl": ">= 2.3.0"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Currently whenever I run `npm i` I see following warnings:

```bash
npm WARN storybook-addon-intl@2.3.1 requires a peer of @storybook/addons@^3.2.16 but none is installed. You must install peer dependencies yourself.
npm WARN storybook-addon-intl@2.3.1 requires a peer of @storybook/react@^3.2.16 but none is installed. You must install peer dependencies yourself.
```

This is not true, as I already have both installed in the higher versions, eg `"@storybook/react": "^4.0.9"`.

This PR should fix this issue.