### PR TITLE
Update html lang attribute on set locale

### DIFF
--- a/src/preview/containers/WithIntl/index.js
+++ b/src/preview/containers/WithIntl/index.js
@@ -25,6 +25,9 @@ class WithIntl extends React.Component {
     }
 
     setLocale (locale) {
+        // Update html lang attribute
+        window.document.documentElement.lang = locale;
+
         this.setState({
             locale: locale
         });


### PR DESCRIPTION
Some components can rely on HTML lang attributes, and I think it worth it to update the HTML lang attribute on set locale

This fixes the related issue:
https://github.com/truffls/storybook-addon-intl/issues/28