### PR TITLE
[Feature] Adds `defaultRichTextElements` prop

### DIFF
--- a/.storybook/stories/01-Message.stories.js
+++ b/.storybook/stories/01-Message.stories.js
@@ -6,6 +6,19 @@ const meta = {
     title: 'Example/01 Message'
 };
 
+const messagesRichText = {
+    en: {
+        message:
+            'Something <strong>important</strong>.<br></br>Something <underline>underlined</underline>.'
+    },
+    es: {
+        message:
+            'Algo <strong>importante</strong>.<br></br>Algo <underline>subrayado</underline>.'
+    }
+};
+
+const getMessages = (locale) => messagesRichText[locale];
+
 export default meta;
 
 export const Default = () => {
@@ -16,5 +29,20 @@ export const PerStory = Default.bind(null);
 PerStory.parameters = {
     intl: {
         locales: [...defaultLocales, 'es']
+    }
+};
+
+export const RichTextElements = Default.bind(null);
+RichTextElements.parameters = {
+    intl: {
+        locales: ['en', 'es'],
+        getMessages,
+        defaultRichTextElements: {
+            br: () => <br />,
+            strong: (text) => <strong>{text}</strong>,
+            underline: (text) => (
+                <span style={{ textDecoration: 'underline' }}>{text}</span>
+            )
+        }
     }
 };

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Fallback locale.
 
 Type: `(locale: string) => object`
 
-Getter function that takes the active locale as arguments and expects an object of messages as return value.
+Getter function that takes the active locale as arguments and expects an `object` of messages as a return value.
 
 <small>(See `messages` in [`IntlProvider` docs](https://formatjs.io/docs/react-intl/components#intlprovider) of react-intl)</small>
 
@@ -71,6 +71,14 @@ Getter function that takes the active locale as arguments and expects an object 
 
 Type: `(locale: string) => object`
 
-Getter function that takes the active locale as arguments and expects an formats objects as return value.
+Getter function that takes the active locale as arguments and expects an `object` of formats as a return value.
 
 <small>(See `formats` in [`IntlProvider` docs](https://formatjs.io/docs/react-intl/components#intlprovider) of react-intl)</small>
+
+### `defaultRichTextElements`
+
+Type: `object`
+
+Object of rich text elements.
+
+<small>(See `defaultRichTextElements` in [`IntlProvider` docs](https://formatjs.io/docs/react-intl/components#intlprovider) of react-intl)</small>

--- a/src/preview/decorators/withIntl.js
+++ b/src/preview/decorators/withIntl.js
@@ -25,7 +25,7 @@ export function withIntl(StoryFn, context) {
         return null;
     }
 
-    const { getMessages, getFormats } = intlConfig;
+    const { getMessages, getFormats, defaultRichTextElements } = intlConfig;
 
     const messages = getMessages(activeLocale);
     const formats =
@@ -36,6 +36,7 @@ export function withIntl(StoryFn, context) {
             locale={activeLocale}
             messages={messages}
             formats={formats}
+            defaultRichTextElements={defaultRichTextElements}
         >
             {StoryFn()}
         </IntlProvider>

--- a/src/utils/validateConfig.js
+++ b/src/utils/validateConfig.js
@@ -12,7 +12,11 @@ export function validateConfig(config) {
         return 'invalid-get-messages';
     } else if (!!config.getFormats && typeof config.getFormats !== 'function') {
         return 'invalid-get-formats';
+    } else if (
+        !!config.defaultRichTextElements &&
+        typeof config.defaultRichTextElements !== 'object'
+    ) {
+        return 'invalid-rich-text-elements';
     }
-
     return null;
 }


### PR DESCRIPTION
🤖 Resolves #118.

## 👋 Introduction

This PR adds `defaultRichTextElements` to the `IntlProvider` component as a prop.

## 🎩 Credit

h/t to @esizer for a sound mind!

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run storybook`
2. Navigate to **Rich Text Elements** story
3. Observe the rich text elements of the string 

## 📸 Screenshot
![Screen Shot 2023-05-02 at 13 19 21](https://user-images.githubusercontent.com/3046459/235738479-15f9db07-c728-4bf5-9a92-8057de274d4f.png)
